### PR TITLE
Stop actor on disconnect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,7 @@ export class Index extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    this.blockClockActor?.stop();
   }
 
   render() {


### PR DESCRIPTION
We should stop the actor on lit component disconnect otherwise when the component is unmounted the machine will keep running.